### PR TITLE
Fix crashes from control center

### DIFF
--- a/ios/RNAudioPlayer/RNAudioPlayer.m
+++ b/ios/RNAudioPlayer/RNAudioPlayer.m
@@ -70,7 +70,6 @@ RCT_EXPORT_METHOD(play:(NSString *)url:(NSDictionary *) metadata) {
         [self.playerItem removeObserver:self forKeyPath:@"playbackLikelyToKeepUp"];
     } @catch (id exception){
         // do nothing if there were no observers attached
-        NSLog(@"no observers were attached");
     }
     
     // metadata to be used in lock screen & control center display
@@ -81,7 +80,6 @@ RCT_EXPORT_METHOD(play:(NSString *)url:(NSDictionary *) metadata) {
     
     // updating lock screen & control center
     [self setNowPlayingInfo:true];
-    NSLog(@"setNowPlayingInfo sent? %@", songTitle);
     
     NSURL *soundUrl = [[NSURL alloc] initWithString:url];
     self.playerItem = [AVPlayerItem playerItemWithURL:soundUrl];
@@ -100,7 +98,6 @@ RCT_EXPORT_METHOD(pause) {
 }
 
 RCT_EXPORT_METHOD(resume) {
-    NSLog(@"resume?!?!?");
     [self.bridge.eventDispatcher sendDeviceEventWithName: @"onPlaybackStateChanged"
                                                     body: @{@"state": @"PLAYING" }];
     [self playAudio];
@@ -371,19 +368,13 @@ RCT_EXPORT_METHOD(seekTo:(int) nSecond) {
 }
 
 - (void)didReceiveNextTrackCommand:(MPRemoteCommand *)event {
-    // if duration exists
-    if (duration != 0) {
-        [self.bridge.eventDispatcher sendDeviceEventWithName: @"onPlaybackActionChanged"
-                                                        body: @{@"action": @"SKIP_TO_NEXT" }];
-    }
+    [self.bridge.eventDispatcher sendDeviceEventWithName: @"onPlaybackActionChanged"
+                                                    body: @{@"action": @"SKIP_TO_NEXT" }];
 }
 
 - (void)didReceivePreviousTrackCommand:(MPRemoteCommand *)event {
-    // if duration exists
-    if (duration != 0) {
-        [self.bridge.eventDispatcher sendDeviceEventWithName: @"onPlaybackActionChanged"
-                                                        body: @{@"action": @"SKIP_TO_PREVIOUS" }];
-    }
+    [self.bridge.eventDispatcher sendDeviceEventWithName: @"onPlaybackActionChanged"
+                                                    body: @{@"action": @"SKIP_TO_PREVIOUS" }];
 }
 
 - (void)unregisterRemoteControlEvents {


### PR DESCRIPTION
### Issues: 
1. tapping play, skip_to_next, skip_to_prev on control center when playlist is empty
2. tapping play, skip_to_next, skip_to_prev on control center when current track is removed

### Resolution: 
iOS test - OK (except tapping skip_to_next, skip_to_prev when there is no track to play) 

### Comments:
It may be better to handle skip_to_next, skip_to_prev logic when there is no track to play in js code
so that case wasn't fixed from this PR (needs test & discussion) 