### PR TITLE
Fix crash caused by calling prop not available on iOS 9 or older

### DIFF
--- a/ios/RNAudioPlayer/RNAudioPlayer.m
+++ b/ios/RNAudioPlayer/RNAudioPlayer.m
@@ -84,7 +84,11 @@ RCT_EXPORT_METHOD(play:(NSString *)url:(NSDictionary *) metadata) {
     NSURL *soundUrl = [[NSURL alloc] initWithString:url];
     self.playerItem = [AVPlayerItem playerItemWithURL:soundUrl];
     self.player = [AVPlayer playerWithPlayerItem:self.playerItem];
-    self.player.automaticallyWaitsToMinimizeStalling = false;
+    
+    // checking if iOS 10 or newer
+    if ([[UIDevice currentDevice].systemVersion floatValue] >= 10) {
+        self.player.automaticallyWaitsToMinimizeStalling = false;
+    }
     
     // adding observers to check if audio is ready to play or it has an issue
     [self.playerItem addObserver:self forKeyPath:@"status" options:0 context:nil];


### PR DESCRIPTION
### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Fix crash caused by calling `automaticallyWaitsToMinimizeStalling` on iOS 9 or older

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
- iOS 9.0 test - OK
- Call `automaticallyWaitsToMinimizeStalling` only when OS version is equal or greater than 10

### Links
Related: https://github.com/AllThatSeries/fym_mobile/issues/590

