### PR TITLE
Handle playback error 

### DIFF
--- a/ios/RNAudioPlayer/RNAudioPlayer.m
+++ b/ios/RNAudioPlayer/RNAudioPlayer.m
@@ -211,8 +211,13 @@ RCT_EXPORT_METHOD(seekTo:(int) nSecond) {
             [self playAudio];
             
         } else if (self.player.currentItem.status == AVPlayerItemStatusFailed) {
-            [self.bridge.eventDispatcher sendDeviceEventWithName: @"onPlaybackStateChanged"
-                                                            body: @{@"state": @"STOPPED" }];
+            if (self.player.currentItem.error) {
+                [self.bridge.eventDispatcher sendDeviceEventWithName: @"onPlaybackError"
+                                                                body: @{@"desc": self.player.currentItem.error.localizedDescription }];
+            } else {
+                [self.bridge.eventDispatcher sendDeviceEventWithName: @"onPlaybackError"
+                                                                body: @{@"desc": @"" }];
+            }
         }
     } else if (object == self.player.currentItem && [keyPath isEqualToString:@"playbackLikelyToKeepUp"]) {
         // check if player has paused && player has begun playing


### PR DESCRIPTION
### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Handle playback error by sending error msg to js code

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
iOS test - OK
- send error message to js code when item status is AVPlayerItemStatusFailed

### Links
Related: https://github.com/AllThatSeries/fym_mobile/issues/612
